### PR TITLE
Bug fix and ps2+xboxOne controller setup

### DIFF
--- a/PlayStationController.js
+++ b/PlayStationController.js
@@ -31,7 +31,32 @@
 		4,5
 	],
 
-	PS2: [],
+	PS2: [
+		1,0,2,5,
+		8,9,
+		9,9,9,9, //dpads for ps2 actually works as a axis 9. P.S. values below are rounded
+		/*
+		Idle:		3.2857
+		Up:			1
+		Right:		-0.42857
+		Down:		0
+		Left:		0.714
+		this program does not uses Dpads, so it will be fine, but if future programs uses this, it might cause error for ps2 controller.
+		*/
+		0,1,2,3,
+		4,5,
+		6,7
+	],
+
+	xboxOne: [
+		1,0,3,2,
+		8,9,
+		12,15,17,18,
+		3,1,0,2,
+		6,7,
+		4,5
+	],
+
 
 	/* 
 	running this method will start the the system using the given controller values.

--- a/game.js
+++ b/game.js
@@ -26,7 +26,7 @@ Soccer.game.prototype = {
 var player = [0, 0];
 var startx = [100, 900];
 var starty = 410;
-var facing = ['right', 'left'];
+var facing = ['idle', 'idle'];
 var pad = [0, 0];
 var boostcooldown = [0, 0];
 
@@ -228,6 +228,8 @@ var countDownTimer = 0;
 
 function updatefunc() {
 
+    debug();
+
     if (countingDown) {
         // console.log("Counting Down"); 
         console.log("Count: " + countDownCount);
@@ -393,6 +395,11 @@ function resetGame() {
     player[0].reset(startx[0],starty);
     player[1].reset(startx[1],starty);
     player[1].animations.play('leftstill');
+    player[0].animations.play('rightstill');
+    facing[0] = 'idle';
+    facing[1] = 'idle';
+
+
 
     ball.reset(500,0);
 
@@ -530,4 +537,13 @@ var winner;
 function endGame(x) {
     winner = x;
     game.state.start('end');
+}
+
+
+function debug()
+{
+    //this is where I can put some debug log statements
+
+    console.log('facing: ' + facing[0]);
+
 }


### PR DESCRIPTION
PS2 (dualshock2) and Xbox one controller (NOT 360) are included. To change controller settings, game.js must be opened and change 'PS3' to 'PS2' or 'xboxOne'. Some code reading is encouraged. (P.S. PS2 Dpad isn't working very well, but it is not necessary for this game)

Also, fixed a bug that when player is moved toward where it is facing every beginning of the match, (player 0 going right or player 1 goint left) player sprite's animation is not updated. That is, players are stuck in to "still" motion while they are moving. If player stop or move left, then they start to work again. I fixed this bug by setting both players in "idle" position. Animation only occurs when they are idle or opposite direction.